### PR TITLE
Improve config error handling and add tests

### DIFF
--- a/FTP_Connection.py
+++ b/FTP_Connection.py
@@ -14,6 +14,11 @@ logging.basicConfig(level=logging.INFO, filename='ftp_client.log', filemode='w',
 # Função para carregar as configurações de conexão do arquivo connections.ini
 def load_ftp_config():
     config = configparser.ConfigParser()
+    if not os.path.exists('connections.ini'):
+        messagebox.showerror("Erro", "Arquivo 'connections.ini' não encontrado.")
+        logging.error("Arquivo 'connections.ini' não encontrado.")
+        raise FileNotFoundError("connections.ini not found")
+
     try:
         config.read('connections.ini')
         host = config.get('FTP', 'host')
@@ -21,10 +26,10 @@ def load_ftp_config():
         user = config.get('FTP', 'user')
         password = config.get('FTP', 'password')
         return host, port, user, password
-    except FileNotFoundError:
-        messagebox.showerror("Erro", "Arquivo 'connections.ini' não encontrado.")
-        logging.error("Arquivo 'connections.ini' não encontrado.")
-        raise  # Re-raise a exceção para que o programa possa lidar com isso
+    except configparser.Error as e:
+        messagebox.showerror("Erro", f"Configuração inválida: {e}")
+        logging.error(f"Erro ao ler 'connections.ini': {str(e)}")
+        raise
 
 
 # Popup de "Aguarde"

--- a/tests/test_load_config.py
+++ b/tests/test_load_config.py
@@ -1,0 +1,28 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+import configparser
+
+import FTP_Connection
+
+class TestLoadFtpConfig(unittest.TestCase):
+    def test_missing_option_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cwd = os.getcwd()
+            os.chdir(tmp)
+            try:
+                with open('connections.ini', 'w') as f:
+                    f.write('[FTP]\n')
+                    f.write('host=localhost\n')
+                    f.write('port=21\n')
+                    f.write('password=secret\n')  # missing user option
+                with patch.object(FTP_Connection, 'messagebox') as mock_msg:
+                    with self.assertRaises(configparser.Error):
+                        FTP_Connection.load_ftp_config()
+                    self.assertTrue(mock_msg.showerror.called)
+            finally:
+                os.chdir(cwd)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- handle missing keys/sections when reading `connections.ini`
- show messagebox when config sections or keys are absent
- add regression test for a missing option

## Testing
- `python3 -m unittest discover tests -v`


------
https://chatgpt.com/codex/tasks/task_e_6844ca5fdb24832f9cb3eacb58a780b6