### PR TITLE
Set default client host

### DIFF
--- a/FTP_Connection.py
+++ b/FTP_Connection.py
@@ -49,6 +49,9 @@ def upload_file(ftp, file_path, file_name):
         return False
 
 
+# Definição do host padrão para a conexão do cliente
+host_var = tk.StringVar(value='127.0.0.1')
+
 # Função para realizar download de arquivo
 def download_file(ftp, file_name, download_path):
     try:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ One FTP Server
 1. Run the server
 2. Run the client
 3. Connect to the server
-4. Use the client to upload and download files -- configure the connection settings in the connections.ini.
+4. Use the client to upload and download files -- configure the connection settings in the connections.ini. The client defaults to connecting to `127.0.0.1` unless you override `host` in that file.
 5. To use the FTP server, you need to configure the config.ini to start up the server
 
 ## How to run the server


### PR DESCRIPTION
## Summary
- add `host_var` with default 127.0.0.1 in `FTP_Connection.py`
- document the localhost default in the README

## Testing
- `python -m py_compile FTP_Connection.py FTP_server.py`

------
https://chatgpt.com/codex/tasks/task_e_6844ca610d44832fadb82c2ff04fafb9